### PR TITLE
fix Tkinter module install at ArchLinux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ elif [ -f /etc/SUSE-brand ]; then
     sudo zypper install -y python3-setuptools python3-devel python3-pip python3-tk
 elif [ -f /etc/arch-release ]; then
     # ArchLinux
-    sudo pacman -S python3-setuptools python3-devel python3-pip python3-tk
+    sudo pacman -S python3-setuptools python3-devel python3-pip tk
 else
     echo "unknown system type."
     exit 1

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,9 @@ elif [ -f /etc/debian_version ]; then
 elif [ -f /etc/SUSE-brand ]; then
     # SUSE
     sudo zypper install -y python3-setuptools python3-devel python3-pip python3-tk
+elif [ -f /etc/arch-release ]; then
+    # ArchLinux
+    sudo pacman -S python3-setuptools python3-devel python3-pip python3-tk
 else
     echo "unknown system type."
     exit 1


### PR DESCRIPTION
Sorry, I make a mistake at previous commit, the Tkinter module in ArchLinux named 'tk'.