### PR TITLE
Add flexiblity in id data for zone size

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     },
     "python.testing.pytestArgs": [
         //"-s", "--log-cli-level=DEBUG", // uncomment for more debug logging in pytest
-        "--pciaddr=XXXX:BB:DD.F"         // BDF address of the DUT. >>> Backup your data! <<<
+        "--pciaddr=0000:00:03.0"         // BDF address of the DUT. >>> Backup your data! <<<
     ],
     "python.pythonPath": "python3",
     "python.testing.unittestEnabled": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     },
     "python.testing.pytestArgs": [
         //"-s", "--log-cli-level=DEBUG", // uncomment for more debug logging in pytest
-        "--pciaddr=0000:00:03.0"         // BDF address of the DUT. >>> Backup your data! <<<
+        "--pciaddr=XXXX:BB:DD.F"         // BDF address of the DUT. >>> Backup your data! <<<
     ],
     "python.pythonPath": "python3",
     "python.testing.unittestEnabled": false,

--- a/scripts/zns.py
+++ b/scripts/zns.py
@@ -152,11 +152,11 @@ works with ioworker.
         return self._ns.read(qpair, buf, self.slba+offset, lba_count,
                              io_flags, dword13, dword14, dword15, cb)
 
-    def append(self, qpair, buf, slba=None, cb=None):
+    def append(self, qpair, buf, slba=None, lba_count=1, cb=None):
         if slba is None:
             slba = self.slba
         return self._ns.send_cmd(opcode=0x7d, qpair=qpair, buf=buf, nsid=self._ns.nsid,
-                 cdw10=slba&0xffffffff, cdw11=slba>>32, cdw12=0,
+                 cdw10=slba&0xffffffff, cdw11=slba>>32, cdw12=lba_count-1,
                  cdw13=0, cdw14=0, cdw15=0, cb=cb)
 
     def ioworker(self, io_size=8, lba_step=None, lba_align=None,

--- a/scripts/zns.py
+++ b/scripts/zns.py
@@ -76,7 +76,7 @@ works with ioworker.
         self.zsze = self._ns.id_data(2831, 2816, cns=5, csi=2)
         logging.debug("zone size 0x%x" % self.zsze)
         if self.zsze == 0:
-            zsze = self.capacity
+            zsze = 0x8000
         logging.debug("create zone [0x%x, 0x%x)]" % (self.slba, self.elba))
 
         for s in range(self.slba, self.elba, self.zsze ):

--- a/src/driver_wrap.pyx
+++ b/src/driver_wrap.pyx
@@ -1227,7 +1227,7 @@ cdef class Controller(object):
                             cb_arg=<void*>cb)
         return self
 
-    def id_data(self, byte_end, byte_begin=None, type=int, nsid=0, cns=1):
+    def id_data(self, byte_end, byte_begin=None, type=int, nsid=0, cns=1, cntid=0, csi=0, nvmsetid=0):
         """get field in controller identify data
 
         # Parameters
@@ -1240,7 +1240,7 @@ cdef class Controller(object):
         """
 
         id_buf = Buffer(4096)
-        self.identify(id_buf, nsid, cns).waitdone()
+        self.identify(id_buf, nsid=nsid, cns=cns, cntid=cntid, csi=csi, nvmsetid=nvmsetid).waitdone()
         return id_buf.data(byte_end, byte_begin, type)
 
     def getfeatures(self, fid, sel=0, buf=None,
@@ -1908,7 +1908,7 @@ cdef class Namespace(object):
         assert opcode < 256
         return self._nvme.supports(256+opcode)
 
-    def id_data(self, byte_end, byte_begin=None, type=int):
+    def id_data(self, byte_end, byte_begin=None, type=int, cns=1, csi=0, cntid=0):
         """get field in namespace identify data
 
         # Parameters
@@ -1920,7 +1920,7 @@ cdef class Namespace(object):
             (int or str): the data in the specified field
         """
 
-        return self._nvme.id_data(byte_end, byte_begin, type, self._nsid, 0)
+        return self._nvme.id_data(byte_end, byte_begin, type, nsid=self._nsid, cns=cns, cntid=cntid, csi=csi)
 
     def verify_enable(self, enable=True):
         """enable or disable the inline verify function of the namespace

--- a/src/driver_wrap.pyx
+++ b/src/driver_wrap.pyx
@@ -1908,7 +1908,7 @@ cdef class Namespace(object):
         assert opcode < 256
         return self._nvme.supports(256+opcode)
 
-    def id_data(self, byte_end, byte_begin=None, type=int, cns=1, csi=0, cntid=0):
+    def id_data(self, byte_end, byte_begin=None, type=int, cns=0, csi=0, cntid=0):
         """get field in namespace identify data
 
         # Parameters


### PR DESCRIPTION
Add flexibility in identify data for controller or namespace, such that we can get zns zone size from ns.id_data