### PR TITLE
Correct makefile pciaddr

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     },
     "python.testing.pytestArgs": [
         //"-s", "--log-cli-level=DEBUG", // uncomment for more debug logging in pytest
-        "--pciaddr=XXXX:BB:DD.F"         // BDF address of the DUT. >>> Backup your data! <<<
+        "--pciaddr=0000:05:00.0"         // BDF address of the DUT. >>> Backup your data! <<<
     ],
     "python.pythonPath": "python3",
     "python.testing.unittestEnabled": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     },
     "python.testing.pytestArgs": [
         //"-s", "--log-cli-level=DEBUG", // uncomment for more debug logging in pytest
-        "--pciaddr=0000:05:00.0"         // BDF address of the DUT. >>> Backup your data! <<<
+        "--pciaddr=XXXX:BB:DD.F"         // BDF address of the DUT. >>> Backup your data! <<<
     ],
     "python.pythonPath": "python3",
     "python.testing.unittestEnabled": false,

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,12 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-#find the first NVMe device as the DUT
-pciaddr := $(shell lspci -D | grep 'Non-Volatile memory' | grep -o '....:..:..\..' | tail -1)
+#Use specified pciaddr or the last NVMe device as the DUT
+ifdef pciaddr
+	pciaddr=pciaddr
+else
+	pciaddr := $(shell lspci -D | grep 'Non-Volatile memory' | grep -o '....:..:..\..' | tail -1)
+endif
 
 #reserve memory for driver
 memsize := 2430   # minimal RAM: 4GB. 2.5GB for pynvme, 1.5GB for system
@@ -104,7 +108,7 @@ tags:
 	ctags -e --c-kinds=+l -R --exclude=.git --exclude=ioat --exclude=snippets --exclude=env --exclude=doc
 
 pytest: info
-	sudo python3 -B -m pytest $(TESTS) --pciaddr=${pciaddr} -s -v -r Efsx --excelreport=report.xls --verbose
+	sudo python3 -B -m pytest --pciaddr=${pciaddr} $(TESTS) -s -v -r Efsx --excelreport=report.xls --verbose
 
 test:
 	- rm test_${pciaddr}.log


### PR DESCRIPTION
Add custom pciaddr in the make. 

Correct make test when specify a custom nvme pcie addr in TESTS as the specified addr will be replaced by the last NVMe drive's pcie. Now we can specify the correct custom pcie addr, but the log file will be still the last pcie.

Use custom pciaddr in make instead of TESTS string can correct the log file name using the correct pciaddr.

$ make pciaddr=01:00.0 test TESTS=scripts/test_examples.py::test_hello_world
rm test_01:00.0.log
make pytest 2>test_01:00.0.log | tee -a test_01:00.0.log
...

git --no-pager log -1
commit c082e80974327ddb1a69fbf4a3146c1ffb2cb496
Author: Crane Chu <cranechu@gmail.com>
Date:   Wed Dec 16 16:25:03 2020 +0800

    update pynvme3 features and contacts
sudo python3 -B -m pytest --pciaddr=01:00.0 scripts/test_examples.py::test_hello_world -s -v -r Efsx --excelreport=report.xls --verbose
============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/ygao/pynvme21, inifile: pytest.ini
plugins: cov-2.8.1, excel-1.4.1
collecting ... collected 1 item

scripts/test_examples.py::test_hello_world 
-------------------------------- live log setup --------------------------------
[2021-01-05 22:56:39.424] INFO script(60): setup random seed: 0xfc9bad55
PASSED
------------------------------ live log teardown -------------------------------
[2021-01-05 22:56:39.591] INFO script(62): test duration: 0.167 sec